### PR TITLE
Fix timer-bug

### DIFF
--- a/promtail/jsonclient.go
+++ b/promtail/jsonclient.go
@@ -113,8 +113,8 @@ func (c *clientJson) run() {
 				c.send(batch)
 				batch = []*jsonLogEntry{}
 				batchSize = 0
-				maxWait.Reset(c.config.BatchWait)
 			}
+			maxWait.Reset(c.config.BatchWait)
 		}
 	}
 }


### PR DESCRIPTION
When maxWait expires the current batch gets sent. Timer is then reset to maxWait and batchSize to zero. If no logs are sent during this maxWait, the timer expires but is not reset. After that any number of logs < config.BatchEntriesNumber is not sent, because there is not timer anymore.
Solution is to move maxWait.Reset out of the if-Block.