### PR TITLE
add support to change the prefix format

### DIFF
--- a/examples/client-example/main.go
+++ b/examples/client-example/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
+	"github.com/afiskon/promtail-client/promtail"
 	"log"
 	"os"
 	"time"
-	"github.com/afiskon/promtail-client/promtail"
 )
 
 func displayUsage() {
@@ -20,13 +20,13 @@ func displayInvalidName(arg string) {
 
 func nameIsValid(name string) bool {
 	for _, c := range name {
-        if !((c >= 'a' && c <= 'z') ||
-             (c >= 'A' && c <= 'Z') ||
-             (c >= '0' && c <= '9') ||
-             (c == '-') || (c == '_')) {
-            return false
-        }
-    }
+		if !((c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') ||
+			(c == '-') || (c == '_')) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -50,19 +50,19 @@ func main() {
 		displayInvalidName("job-name")
 	}
 
-	labels := "{source=\""+source_name+"\",job=\""+job_name+"\"}"
+	labels := "{source=\"" + source_name + "\",job=\"" + job_name + "\"}"
 	conf := promtail.ClientConfig{
 		PushURL:            "http://localhost:3100/api/prom/push",
 		Labels:             labels,
 		BatchWait:          5 * time.Second,
 		BatchEntriesNumber: 10000,
-		SendLevel: 			promtail.INFO,
-		PrintLevel: 		promtail.ERROR,
+		SendLevel:          promtail.INFO,
+		PrintLevel:         promtail.ERROR,
 	}
 
 	var (
 		loki promtail.Client
-		err error
+		err  error
 	)
 
 	if format == "proto" {
@@ -78,8 +78,8 @@ func main() {
 
 	for i := 1; i < 5; i++ {
 		tstamp := time.Now().String()
-		loki.Debugf("source = %s time = %s, i = %d\n", source_name, tstamp, i)
-		loki.Infof("source = %s, time = %s, i = %d\n", source_name, tstamp, i)
+		loki.Debugf("source=%s time = %s, i = %d\n", source_name, tstamp, i)
+		loki.Infof("source=%s, time = %s, i = %d\n", source_name, tstamp, i)
 		loki.Warnf("source = %s, time = %s, i = %d\n", source_name, tstamp, i)
 		loki.Errorf("source = %s, time = %s, i = %d\n", source_name, tstamp, i)
 		time.Sleep(1 * time.Second)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/afiskon/promtail-client
+
+go 1.17
+
+require (
+	github.com/golang/protobuf v1.5.2
+	github.com/golang/snappy v0.0.4
+)
+
+require google.golang.org/protobuf v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/promtail/common.go
+++ b/promtail/common.go
@@ -31,6 +31,8 @@ type ClientConfig struct {
 	SendLevel LogLevel
 	// Logs are printed to stdout if the entry level is >= PrintLevel
 	PrintLevel LogLevel
+	// fmt string to express the prefix
+	PrefixFormat string
 }
 
 type Client interface {


### PR DESCRIPTION
The prefix is hardcoded as "Debug: ",  "Warn: " etc,  with this PR that format is the same
but you can pass a prefixFormat wheren you can change for example how is printed.

default format: "%s: "
imagine an example: "level=%s "

so the line would looks like: " level=Debug "

Thanks