### PR TITLE
Add customer label parameter and a new method without prefix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+go.mod
+go.sum

--- a/examples/client-example/main.go
+++ b/examples/client-example/main.go
@@ -20,13 +20,13 @@ func displayInvalidName(arg string) {
 
 func nameIsValid(name string) bool {
 	for _, c := range name {
-		if !((c >= 'a' && c <= 'z') ||
-			(c >= 'A' && c <= 'Z') ||
-			(c >= '0' && c <= '9') ||
-			(c == '-') || (c == '_')) {
-			return false
-		}
-	}
+        if !((c >= 'a' && c <= 'z') ||
+             (c >= 'A' && c <= 'Z') ||
+             (c >= '0' && c <= '9') ||
+             (c == '-') || (c == '_')) {
+            return false
+        }
+    }
 	return true
 }
 
@@ -56,8 +56,8 @@ func main() {
 		Labels:             labels,
 		BatchWait:          5 * time.Second,
 		BatchEntriesNumber: 100,
-		SendLevel:          promtail.INFO,
-		PrintLevel:         promtail.ERROR,
+		SendLevel:			promtail.INFO,
+		PrintLevel: 		promtail.ERROR,
 	}
 
 	var (

--- a/examples/client-example/main.go
+++ b/examples/client-example/main.go
@@ -20,13 +20,13 @@ func displayInvalidName(arg string) {
 
 func nameIsValid(name string) bool {
 	for _, c := range name {
-        if !((c >= 'a' && c <= 'z') ||
-             (c >= 'A' && c <= 'Z') ||
-             (c >= '0' && c <= '9') ||
-             (c == '-') || (c == '_')) {
-            return false
-        }
-    }
+		if !((c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') ||
+			(c == '-') || (c == '_')) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -56,8 +56,8 @@ func main() {
 		Labels:             labels,
 		BatchWait:          5 * time.Second,
 		BatchEntriesNumber: 100,
-		SendLevel: 			promtail.INFO,
-		PrintLevel: 		promtail.ERROR,
+		SendLevel:          promtail.INFO,
+		PrintLevel:         promtail.ERROR,
 	}
 
 	var (

--- a/examples/client-example/main.go
+++ b/examples/client-example/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"promtail/promtail"
 	"time"
-	"github.com/afiskon/promtail-client/promtail"
 )
 
 func displayUsage() {
@@ -50,19 +50,19 @@ func main() {
 		displayInvalidName("job-name")
 	}
 
-	labels := "{source=\""+source_name+"\",job=\""+job_name+"\"}"
+	labels := "{source=\"" + source_name + "\",job=\"" + job_name + "\"}"
 	conf := promtail.ClientConfig{
 		PushURL:            "http://localhost:3100/api/prom/push",
 		Labels:             labels,
 		BatchWait:          5 * time.Second,
-		BatchEntriesNumber: 10000,
+		BatchEntriesNumber: 100,
 		SendLevel: 			promtail.INFO,
 		PrintLevel: 		promtail.ERROR,
 	}
 
 	var (
 		loki promtail.Client
-		err error
+		err  error
 	)
 
 	if format == "proto" {
@@ -82,6 +82,7 @@ func main() {
 		loki.Infof("source = %s, time = %s, i = %d\n", source_name, tstamp, i)
 		loki.Warnf("source = %s, time = %s, i = %d\n", source_name, tstamp, i)
 		loki.Errorf("source = %s, time = %s, i = %d\n", source_name, tstamp, i)
+		loki.LogfWithLabel("{source=\"new_"+source_name+"\"}", "source = %s, time = %s, i = %d\n", source_name, tstamp, i)
 		time.Sleep(1 * time.Second)
 	}
 

--- a/promtail/common.go
+++ b/promtail/common.go
@@ -38,6 +38,11 @@ type Client interface {
 	Infof(format string, args ...interface{})
 	Warnf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
+	DebugfWithLabel(label, format string, args ...interface{})
+	InfofWithLabel(label, format string, args ...interface{})
+	WarnfWithLabel(label, format string, args ...interface{})
+	ErrorfWithLabel(label, format string, args ...interface{})
+	LogfWithLabel(label, format string, args ...interface{})
 	Shutdown()
 }
 

--- a/promtail/jsonclient.go
+++ b/promtail/jsonclient.go
@@ -8,12 +8,17 @@ import (
 	"time"
 )
 
+type jsonLogEntryLabel struct {
+	Label string    `json:"label"`
+	Ts    time.Time `json:"ts"`
+	Line  string    `json:"line"`
+	level LogLevel  // not used in JSON
+}
 type jsonLogEntry struct {
 	Ts    time.Time `json:"ts"`
 	Line  string    `json:"line"`
-	level LogLevel // not used in JSON
+	level LogLevel  // not used in JSON
 }
-
 type promtailStream struct {
 	Labels  string          `json:"labels"`
 	Entries []*jsonLogEntry `json:"entries"`
@@ -26,7 +31,7 @@ type promtailMsg struct {
 type clientJson struct {
 	config    *ClientConfig
 	quit      chan struct{}
-	entries   chan *jsonLogEntry
+	entries   chan *jsonLogEntryLabel
 	waitGroup sync.WaitGroup
 	client    httpClient
 }
@@ -35,7 +40,7 @@ func NewClientJson(conf ClientConfig) (Client, error) {
 	client := clientJson{
 		config:  &conf,
 		quit:    make(chan struct{}),
-		entries: make(chan *jsonLogEntry, LOG_ENTRIES_CHAN_SIZE),
+		entries: make(chan *jsonLogEntryLabel, LOG_ENTRIES_CHAN_SIZE),
 		client:  httpClient{},
 	}
 
@@ -46,24 +51,47 @@ func NewClientJson(conf ClientConfig) (Client, error) {
 }
 
 func (c *clientJson) Debugf(format string, args ...interface{}) {
-	c.log(format, DEBUG, "Debug: ", args...)
+	c.log("", format, DEBUG, "Debug: ", args...)
 }
 
 func (c *clientJson) Infof(format string, args ...interface{}) {
-	c.log(format, INFO, "Info: ", args...)
+	c.log("", format, INFO, "Info: ", args...)
 }
 
 func (c *clientJson) Warnf(format string, args ...interface{}) {
-	c.log(format, WARN, "Warn: ", args...)
+	c.log("", format, WARN, "Warn: ", args...)
 }
 
+func (c *clientJson) Logf(format string, args ...interface{}) {
+	c.log("", format, INFO, "", args...)
+}
 func (c *clientJson) Errorf(format string, args ...interface{}) {
-	c.log(format, ERROR, "Error: ", args...)
+	c.log("", format, ERROR, "Error: ", args...)
 }
 
-func (c *clientJson) log(format string, level LogLevel, prefix string, args ...interface{}) {
+func (c *clientJson) DebugfWithLabel(label, format string, args ...interface{}) {
+	c.log(label, format, DEBUG, "Debug: ", args...)
+}
+
+func (c *clientJson) InfofWithLabel(label, format string, args ...interface{}) {
+	c.log(label, format, INFO, "Info: ", args...)
+}
+
+func (c *clientJson) WarnfWithLabel(label, format string, args ...interface{}) {
+	c.log(label, format, WARN, "Warn: ", args...)
+}
+
+func (c *clientJson) ErrorfWithLabel(label, format string, args ...interface{}) {
+	c.log(label, format, ERROR, "Error: ", args...)
+}
+func (c *clientJson) LogfWithLabel(label, format string, args ...interface{}) {
+	c.log(label, format, INFO, "", args...)
+}
+
+func (c *clientJson) log(label, format string, level LogLevel, prefix string, args ...interface{}) {
 	if (level >= c.config.SendLevel) || (level >= c.config.PrintLevel) {
-		c.entries <- &jsonLogEntry{
+		c.entries <- &jsonLogEntryLabel{
+			Label: label,
 			Ts:    time.Now(),
 			Line:  fmt.Sprintf(prefix+format, args...),
 			level: level,
@@ -77,7 +105,8 @@ func (c *clientJson) Shutdown() {
 }
 
 func (c *clientJson) run() {
-	var batch []*jsonLogEntry
+	var batch map[string][]*jsonLogEntry
+	batch = make(map[string][]*jsonLogEntry)
 	batchSize := 0
 	maxWait := time.NewTimer(c.config.BatchWait)
 
@@ -99,11 +128,20 @@ func (c *clientJson) run() {
 			}
 
 			if entry.level >= c.config.SendLevel {
-				batch = append(batch, entry)
+				if entry.Label == "" {
+					entry.Label = c.config.Labels
+				}
+				batch[entry.Label] = append(batch[entry.Label], &jsonLogEntry{
+					Ts:    entry.Ts,
+					level: entry.level,
+					Line:  entry.Line,
+				})
+
 				batchSize++
 				if batchSize >= c.config.BatchEntriesNumber {
 					c.send(batch)
-					batch = []*jsonLogEntry{}
+					batch = make(map[string][]*jsonLogEntry)
+
 					batchSize = 0
 					maxWait.Reset(c.config.BatchWait)
 				}
@@ -111,7 +149,8 @@ func (c *clientJson) run() {
 		case <-maxWait.C:
 			if batchSize > 0 {
 				c.send(batch)
-				batch = []*jsonLogEntry{}
+				batch = make(map[string][]*jsonLogEntry)
+
 				batchSize = 0
 			}
 			maxWait.Reset(c.config.BatchWait)
@@ -119,13 +158,15 @@ func (c *clientJson) run() {
 	}
 }
 
-func (c *clientJson) send(entries []*jsonLogEntry) {
+func (c *clientJson) send(entries map[string][]*jsonLogEntry) {
 	var streams []promtailStream
-	streams = append(streams, promtailStream{
-		Labels:  c.config.Labels,
-		Entries: entries,
-	})
 
+	for k, v := range entries {
+		streams = append(streams, promtailStream{
+			Labels:  k,
+			Entries: v,
+		})
+	}
 	msg := promtailMsg{Streams: streams}
 	jsonMsg, err := json.Marshal(msg)
 	if err != nil {


### PR DESCRIPTION
update: allow to change label every time, you can pass an empty string in the first parameter when you don't want to change label and use `client.config.Labels`.
add: add a new method `Logf` to submit a logline without prefix such as `ERROR`, `INFO` etc.